### PR TITLE
Use release time when determining when to release non-looping sample voice

### DIFF
--- a/synthvoice/sample.py
+++ b/synthvoice/sample.py
@@ -237,7 +237,7 @@ class Sample(synthvoice.oscillator.Oscillator):
         if (
             not self.looping
             and not self._start is None
-            and time.monotonic() - self._start >= self.duration
+            and time.monotonic() - self._start >= self.duration - self._release_time
         ):
             self.release()
             self._start = None


### PR DESCRIPTION
This is a very simple update which allows for the `Sample.release_time` property to modify the timing of which the note is released when `looping=False`.